### PR TITLE
chore(corejs): upgrade lodash (Aikido)

### DIFF
--- a/corejs/package.json
+++ b/corejs/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "fast-json-patch": "^3.1.1",
     "formdata-polyfill": "^4.0.10",
-    "lodash": "^4.17.23",
+    "lodash": "^4.18.1",
     "query-string": "^9.1.1",
     "tiny-emitter": "^2.1.0",
     "unidecode": "^1.1.0",

--- a/corejs/pnpm-lock.yaml
+++ b/corejs/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^4.0.10
         version: 4.0.10
       lodash:
-        specifier: ^4.17.23
-        version: 4.17.23
+        specifier: ^4.18.1
+        version: 4.18.1
       query-string:
         specifier: ^9.1.1
         version: 9.1.1
@@ -1260,8 +1260,8 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   loupe@2.3.7:
     resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
@@ -3105,7 +3105,7 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
-  lodash@4.17.23: {}
+  lodash@4.18.1: {}
 
   loupe@2.3.7:
     dependencies:
@@ -3614,7 +3614,7 @@ snapshots:
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1
       esquery: 1.6.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       semver: 7.7.1
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
## Summary
- Upgraded corejs lodash from 4.17.23 → 4.18.1

## Aikido sub-issues resolved
| sub_issue | package | CVE | Aikido |
|---|---|---|---|
| #209368027 | lodash | CVE-2026-2950 | [link](https://app.aikido.dev/issues/25891592/detail?status=open&team_id_filter=296964) |
| #209368025 | lodash | CVE-2026-4800 | [link](https://app.aikido.dev/issues/25891592/detail?status=open&team_id_filter=296964) |

(Exact sub_issue IDs belong to group 25891592 — check the team dashboard after merge.)

## Verification
- `pnpm ci-test` passes (70 tests)
- `pnpm build` passes
- `go build ./... && go test -short ./...` passes

## Deployment Note
Skill does not touch `release-*` branches. Merging this PR and promoting to a release branch is handled per team policy.